### PR TITLE
fix: Migrate to farcasterMiniApp connector

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -18,7 +18,6 @@
   "dependencies": {
     "@divvi/referral-sdk": "^2.0.0",
     "@farcaster/frame-sdk": "^0.1.12",
-    "@farcaster/frame-wagmi-connector": "^1.0.0",
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@farcaster/miniapp-wagmi-connector": "^1.1.0",
     "@farcaster/quick-auth": "^0.0.8",

--- a/packages/nextjs/services/web3/wagmiConfig.tsx
+++ b/packages/nextjs/services/web3/wagmiConfig.tsx
@@ -1,5 +1,5 @@
 import { wagmiConnectors } from "./wagmiConnectors";
-import { farcasterFrame } from "@farcaster/frame-wagmi-connector";
+import { farcasterMiniApp } from "@farcaster/miniapp-wagmi-connector";
 import { Chain, createClient, fallback, http } from "viem";
 import { hardhat, mainnet } from "viem/chains";
 import { createConfig } from "wagmi";
@@ -15,7 +15,7 @@ export const enabledChains = targetNetworks.find((network: Chain) => network.id 
 
 export const wagmiConfig = createConfig({
   chains: enabledChains,
-  connectors: [farcasterFrame(), ...wagmiConnectors()],
+  connectors: [farcasterMiniApp(), ...wagmiConnectors()],
   ssr: true,
   client: ({ chain }) => {
     let rpcFallbacks = [http()];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,17 +1514,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@farcaster/frame-wagmi-connector@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@farcaster/frame-wagmi-connector@npm:1.0.0"
-  peerDependencies:
-    "@farcaster/frame-sdk": ^0.1.0
-    "@wagmi/core": ^2.14.1
-    viem: ^2.21.55
-  checksum: 691443b6260e4cc35da30b7bcada1d53453ea234d368aae76db10734156e4acf43c796f2ca61e1ba7b0169caa2521db3cb136292c61e48aa5a3e35db12c2b971
-  languageName: node
-  linkType: hard
-
 "@farcaster/miniapp-core@npm:0.4.1":
   version: 0.4.1
   resolution: "@farcaster/miniapp-core@npm:0.4.1"
@@ -4560,7 +4549,6 @@ __metadata:
   dependencies:
     "@divvi/referral-sdk": ^2.0.0
     "@farcaster/frame-sdk": ^0.1.12
-    "@farcaster/frame-wagmi-connector": ^1.0.0
     "@farcaster/miniapp-sdk": ^0.2.1
     "@farcaster/miniapp-wagmi-connector": ^1.1.0
     "@farcaster/quick-auth": ^0.0.8


### PR DESCRIPTION
- Replace deprecated farcasterFrame with farcasterMiniApp
- Remove @farcaster/frame-wagmi-connector
- Use @farcaster/miniapp-wagmi-connector instead
- Fixes deprecation warnings