### PR TITLE
added base to csp domains and updated miniapp wrappers

### DIFF
--- a/packages/nextjs/components/BaseAppReady.tsx
+++ b/packages/nextjs/components/BaseAppReady.tsx
@@ -5,8 +5,22 @@ import sdk from "@farcaster/miniapp-sdk";
 
 export function BaseAppReady() {
   useEffect(() => {
-    // Call ready() as soon as possible to hide splash screen
-    sdk.actions.ready().catch(console.error);
+    const initializeSDK = async () => {
+      try {
+        // Wait for SDK to be ready before calling actions
+        await sdk.context;
+        await sdk.actions.ready();
+        console.log("SDK ready() called successfully");
+      } catch (error) {
+        console.error("SDK ready() failed:", error);
+        // Fallback: try calling ready() anyway after a delay
+        setTimeout(() => {
+          sdk.actions.ready().catch(console.error);
+        }, 1000);
+      }
+    };
+
+    initializeSDK();
   }, []);
 
   return null;

--- a/packages/nextjs/next.config.ts
+++ b/packages/nextjs/next.config.ts
@@ -31,7 +31,7 @@ const nextConfig: NextConfig = {
               "img-src 'self' data: https: blob:",
               "font-src 'self' data: https://fonts.gstatic.com",
               "connect-src 'self' * wss: ws: https: http: data: blob:",
-              "frame-ancestors 'self' https://farcaster.xyz https://warpcast.com",
+              "frame-ancestors 'self' https://farcaster.xyz https://warpcast.com https://www.base.dev https://base.dev https://app.base.dev https://base.org",
               "worker-src 'self' blob:",
             ].join("; "),
           },


### PR DESCRIPTION
Fix Base App Integration and Room Disconnect Issues
🔧 Base App Mini App Integration
Add Base App SDK integration: Created BaseAppReady component to properly call sdk.actions.ready() with initialization checks

Fix CSP headers: Added Base domains (base.dev, app.base.dev, base.org) to frame-ancestors directive

Update manifest format: Changed from frame to miniapp structure in farcaster.json route

Fix metadata: Updated layout metadata from launch_frame to launch_miniapp

Add FarcasterProvider: Integrated missing provider in app layout

🎮 Game Room Improvements
Fix disconnect publishing: Players can now publish matches even after opponent leaves

Better disconnect UX: Show "Opponent disconnected" status and hide rematch options when appropriate

Prevent auto-navigation: Don't force navigation away from finished games when opponent disconnects

Preserve match data: Ensure gameData remains available for publishing after disconnects

📝 Configuration Updates
Shorten manifest subtitle: Reduced to 25 characters to meet Base app requirements

Enhanced error handling: Added fallback retry logic for SDK initialization

Improved logging: Added console logs for debugging SDK ready state

These changes enable proper Base app embedding while maintaining all existing functionality and improving the multiplayer disconnect experience.